### PR TITLE
Upgrade to 2018 edition of rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+default-members = ["shipcat_cli"]
 members = [
   "raftcat",
   "shipcat_cli"

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ tag-latest:
 	docker push $(REPO)/$(NAME):latest
 
 clippy:
-	cargo clippy -p shipcat -- --allow clippy::if_let_redundant_pattern_matching --allow clippy::or_fun_call
-	@# raftcat uses actix that requires experimental lints - run this manually on nightly..
-	@#cargo clippy -p raftcat -- --allow clippy::or_fun_call
+	touch shipcat_definitions/src/lib.rs
+	cargo clippy -p shipcat -- --allow clippy::or_fun_call --allow clippy::redundant_pattern_matching
+	cargo clippy -p raftcat -- --allow clippy::or_fun_call
 
 
 doc:

--- a/raftcat/Cargo.toml
+++ b/raftcat/Cargo.toml
@@ -2,6 +2,7 @@
 name = "raftcat"
 version = "0.76.0"
 authors = ["Eirik Albrigtsen <eirik.albrigtsen@babylonhealth.com>"]
+edition = "2018"
 
 [[bin]]
 doc = false

--- a/raftcat/src/integrations.rs
+++ b/raftcat/src/integrations.rs
@@ -1,10 +1,7 @@
-use super::{Result};
-
 pub mod version {
-    use reqwest::Url;
+    use crate::Result;
     use std::collections::BTreeMap;
-    use std::env;
-    use super::Result;
+    use reqwest::Url;
 
     // version fetching stuff
     #[derive(Deserialize)]
@@ -20,7 +17,7 @@ pub mod version {
     // The actual HTTP GET logic
     pub fn get_all() -> Result<VersionMap> {
         let client = reqwest::Client::new();
-        let vurl = Url::parse(&env::var("VERSION_URL")?)?;
+        let vurl = Url::parse(&std::env::var("VERSION_URL")?)?;
         let mut res = client.get(vurl).send()?;
         if !res.status().is_success() {
             bail!("Failed to fetch version");
@@ -38,9 +35,8 @@ pub mod version {
 }
 
 pub mod sentryapi {
+    use crate::Result;
     use std::collections::BTreeMap;
-    use super::Result;
-    use std::env;
 
     // Sentry project struct
     #[derive(Deserialize)]
@@ -55,7 +51,7 @@ pub mod sentryapi {
     // Get Sentry info
     pub fn get_slugs(sentry_url: &str, env: &str) -> Result<SentryMap> {
         let client = reqwest::Client::new();
-        let token = env::var("SENTRY_TOKEN")?;
+        let token = std::env::var("SENTRY_TOKEN")?;
 
         let projects_url = format!("{sentry_url}/api/0/teams/sentry/{env}/projects/",
                                    sentry_url = &sentry_url,
@@ -82,10 +78,8 @@ pub mod sentryapi {
 
 
 pub mod newrelic {
+    use crate::Result;
     use std::collections::BTreeMap;
-    use super::Result;
-    use std::env;
-
     // NewRelic Applications info
     #[derive(Deserialize)]
     struct Application {
@@ -103,8 +97,8 @@ pub mod newrelic {
     // Get NewRelic link
     pub fn get_links(region: &str) -> Result<RelicMap> {
         let client = reqwest::Client::new();
-        let api_key = env::var("NEWRELIC_API_KEY")?;
-        let account_id = env::var("NEWRELIC_ACCOUNT_ID")?;
+        let api_key = std::env::var("NEWRELIC_API_KEY")?;
+        let account_id = std::env::var("NEWRELIC_ACCOUNT_ID")?;
 
         let search = format!("({region})", region = region);
         let mut res = client

--- a/raftcat/src/kube.rs
+++ b/raftcat/src/kube.rs
@@ -1,6 +1,5 @@
 use kubernetes::client::APIClient;
 use std::collections::BTreeMap;
-//use serde_json;
 use shipcat_definitions::{Crd, CrdList, CrdEvent, CrdEventType, Manifest, Config};
 
 use super::{Result, Error};

--- a/raftcat/src/lib.rs
+++ b/raftcat/src/lib.rs
@@ -22,10 +22,10 @@ pub use shipcat_definitions::{Manifest, Config, Cluster, Region, Team};
 
 /// A small CLI kubernetes interface
 pub mod kube;
-pub use kube::{ManifestMap, ManifestCache};
+pub use crate::kube::{ManifestMap, ManifestCache};
 
 
 mod integrations;
-pub use integrations::sentryapi::{self, SentryMap};
-pub use integrations::newrelic::{self, RelicMap};
-pub use integrations::version::{self, VersionMap};
+pub use crate::integrations::sentryapi::{self, SentryMap};
+pub use crate::integrations::newrelic::{self, RelicMap};
+pub use crate::integrations::version::{self, VersionMap};

--- a/raftcat/src/lib.rs
+++ b/raftcat/src/lib.rs
@@ -1,11 +1,10 @@
-#![allow(renamed_and_removed_lints)]
 #![warn(rust_2018_idioms)]
 
 #[macro_use] extern crate serde_derive;
 #[macro_use] extern crate log;
 #[macro_use] extern crate failure;
 
-pub use failure::{Error}; //Fail
+pub use failure::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub use shipcat_definitions::{Manifest, Config, Cluster, Region, Team};
@@ -16,6 +15,8 @@ pub use crate::kube::{ManifestMap, ManifestCache};
 
 
 mod integrations;
-pub use crate::integrations::sentryapi::{self, SentryMap};
-pub use crate::integrations::newrelic::{self, RelicMap};
-pub use crate::integrations::version::{self, VersionMap};
+pub use crate::integrations::{
+  sentryapi::{self, SentryMap},
+  newrelic::{self, RelicMap},
+  version::{self, VersionMap},
+};

--- a/raftcat/src/lib.rs
+++ b/raftcat/src/lib.rs
@@ -1,23 +1,13 @@
 #![allow(renamed_and_removed_lints)]
+#![warn(rust_2018_idioms)]
 
 #[macro_use] extern crate serde_derive;
-extern crate serde;
-extern crate serde_json;
-extern crate serde_yaml;
-
-extern crate url;
-extern crate http;
-extern crate kubernetes;
-extern crate reqwest;
-
 #[macro_use] extern crate log;
 #[macro_use] extern crate failure;
 
 pub use failure::{Error}; //Fail
 pub type Result<T> = std::result::Result<T, Error>;
 
-
-extern crate shipcat_definitions;
 pub use shipcat_definitions::{Manifest, Config, Cluster, Region, Team};
 
 /// A small CLI kubernetes interface

--- a/raftcat/src/main.rs
+++ b/raftcat/src/main.rs
@@ -337,7 +337,7 @@ fn main() -> Result<()> {
     let state = StateSafe::new(client)?;
     let state2 = state.clone();
     // continuously poll for updates
-    use std::{thread, time};
+    use std::thread;
     thread::spawn(move || {
         loop {
             thread::sleep(Duration::from_secs(10));

--- a/raftcat/src/main.rs
+++ b/raftcat/src/main.rs
@@ -1,22 +1,11 @@
 #![allow(unused_imports, unused_variables)]
 #[macro_use] extern crate log;
-extern crate env_logger; // TODO: slog + slog-json
-
-extern crate sentry;
-extern crate sentry_actix;
-extern crate actix;
-extern crate actix_web;
-extern crate semver;
 #[macro_use] extern crate tera;
-extern crate kubernetes;
-extern crate chrono;
-
 extern crate failure;
 use failure::err_msg;
 
 #[macro_use] extern crate serde_derive;
 
-extern crate raftcat;
 pub use raftcat::*;
 
 use kubernetes::client::APIClient;

--- a/shipcat_cli/Cargo.toml
+++ b/shipcat_cli/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["command-line-utilities"]
 keywords = ["kubernetes", "helm", "deployment", "standardisation", "validation"]
 license-file = "LICENSE"
 homepage = "https://github.com/Babylonpartners/shipcat"
+edition = "2018"
 
 [[bin]]
 doc = false

--- a/shipcat_cli/src/gdpr.rs
+++ b/shipcat_cli/src/gdpr.rs
@@ -18,8 +18,8 @@ struct GdprOutput {
 pub fn show(svc: Option<String>, conf: &Config, region: &Region) -> Result<()> {
     let out = if let Some(s) = svc {
         let mf = Manifest::base(&s, conf, region)?;
-        let data = if let Some(mut dh) = mf.dataHandling {
-                dh
+        let data = if let Some(dh) = mf.dataHandling {
+            dh
         } else {
             DataHandling::default()
         };
@@ -29,7 +29,7 @@ pub fn show(svc: Option<String>, conf: &Config, region: &Region) -> Result<()> {
         let mut services = vec![];
         for s in Manifest::available(&region.name)? {
             let mf = Manifest::base(&s, conf, region)?;
-            if let Some(mut dh) = mf.dataHandling {
+            if let Some(dh) = mf.dataHandling {
                 mappings.insert(s.clone(), dh);
             }
             services.push(s);

--- a/shipcat_cli/src/get.rs
+++ b/shipcat_cli/src/get.rs
@@ -208,7 +208,7 @@ impl ResourceBreakdown {
 
     /// Round all numbers to gigs and full cores (for all teams)
     pub fn normalise(mut self) -> Self {
-        for mut tt in &mut self.teams.values_mut() {
+        for tt in &mut self.teams.values_mut() {
             tt.base.round();
             tt.extra.round();
         }

--- a/shipcat_cli/src/grafana.rs
+++ b/shipcat_cli/src/grafana.rs
@@ -1,11 +1,12 @@
 ///
 /// Interface for adding grafana annotations about deploys
 ///
-
 use reqwest;
-use super::{Result, ErrorKind, ResultExt};
 use chrono::Utc;
 use std::env;
+use serde_json::json;
+
+use super::{Result, ErrorKind, ResultExt};
 
 /// At what time the annotation should be made
 #[derive(Debug)]

--- a/shipcat_cli/src/graph.rs
+++ b/shipcat_cli/src/graph.rs
@@ -23,7 +23,7 @@ impl ManifestNode {
 }
 // Debug is used for the `dot` interface - nice to have a minimal output for that
 impl Debug for ManifestNode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)
     }
 }

--- a/shipcat_cli/src/helm/direct.rs
+++ b/shipcat_cli/src/helm/direct.rs
@@ -41,7 +41,7 @@ impl Default for UpgradeMode {
 }
 
 impl fmt::Display for UpgradeMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             &UpgradeMode::DiffOnly => write!(f, "diff"),
             &UpgradeMode::UpgradeWait => write!(f, "blindly upgrade"),
@@ -271,7 +271,7 @@ enum DiffMode {
 }
 
 impl fmt::Display for DiffMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             &DiffMode::Upgrade => write!(f, "upgrade"),
             //&DiffMode::Rollback => write!(f, "rollback"),

--- a/shipcat_cli/src/lib.rs
+++ b/shipcat_cli/src/lib.rs
@@ -4,7 +4,6 @@
 #![warn(rust_2018_idioms)]
 
 #[macro_use] extern crate serde_derive;
-#[macro_use] extern crate serde_json;
 #[macro_use] extern crate log;
 
 #[macro_use] extern crate error_chain;

--- a/shipcat_cli/src/lib.rs
+++ b/shipcat_cli/src/lib.rs
@@ -1,40 +1,13 @@
 #![recursion_limit = "1024"]
 #![allow(renamed_and_removed_lints)]
 #![allow(non_snake_case)]
+#![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_yaml;
-extern crate serde;
-#[macro_use]
-extern crate serde_json;
+#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate serde_json;
+#[macro_use] extern crate log;
 
-// grafana / slack
-extern crate reqwest;
-
-extern crate openssl_probe;
-
-extern crate chrono;
-
-// notifications
-extern crate slack_hook;
-
-// graphing
-extern crate petgraph;
-
-#[macro_use]
-extern crate log;
-
-// sanity
-extern crate dirs;
-extern crate regex;
-extern crate semver;
-
-// parallel upgrades:
-extern crate threadpool;
-
-#[macro_use]
-extern crate error_chain;
+#[macro_use] extern crate error_chain;
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;
@@ -97,7 +70,6 @@ error_chain! {
     }
 }
 
-extern crate shipcat_definitions;
 pub use shipcat_definitions::{Manifest, ConfigType};
 pub use shipcat_definitions::structs;
 pub use shipcat_definitions::config::{self, Config, Team};

--- a/shipcat_cli/src/main.rs
+++ b/shipcat_cli/src/main.rs
@@ -1,11 +1,5 @@
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate log;
-extern crate loggerv;
-extern crate libc;
-
-extern crate shipcat;
+#[macro_use] extern crate clap;
+#[macro_use] extern crate log;
 
 #[allow(unused_imports)]
 use shipcat::*;

--- a/shipcat_cli/src/main.rs
+++ b/shipcat_cli/src/main.rs
@@ -1,10 +1,7 @@
 #[macro_use] extern crate clap;
 #[macro_use] extern crate log;
 
-#[allow(unused_imports)]
 use shipcat::*;
-
-#[allow(unused_imports)]
 use clap::{Arg, App, AppSettings, SubCommand, ArgMatches};
 use std::process;
 

--- a/shipcat_cli/src/validate.rs
+++ b/shipcat_cli/src/validate.rs
@@ -29,10 +29,10 @@ pub fn manifest(services: Vec<String>, conf: &Config, reg: &Region, secrets: boo
 pub fn secret_presence(conf: &Config, regions: Vec<String>) -> Result<()> {
     for r in regions {
         info!("validating secrets in {}", r);
-        let mut reg = conf.get_region(&r)?; // verifies region or region alias exists
+        let reg = conf.get_region(&r)?; // verifies region or region alias exists
         reg.verify_secrets_exist()?; // verify secrets for the region
         for svc in Manifest::available(&reg.name)? {
-            let mut mf = Manifest::base(&svc, conf, &reg)?;
+            let mf = Manifest::base(&svc, conf, &reg)?;
             debug!("validating secrets for {} in {}", svc, r);
             mf.verify_secrets_exist(&reg.vault)?;
         }

--- a/shipcat_cli/tests/common.rs
+++ b/shipcat_cli/tests/common.rs
@@ -1,8 +1,4 @@
-extern crate semver;
-extern crate shipcat;
-extern crate shipcat_definitions;
-
-use self::semver::Version;
+use semver::Version;
 use std::collections::BTreeSet;
 use std::env;
 use std::fs;

--- a/shipcat_cli/tests/graph.rs
+++ b/shipcat_cli/tests/graph.rs
@@ -1,7 +1,7 @@
 extern crate serde_yaml;
 mod common;
 
-use common::setup;
+use crate::common::setup;
 
 extern crate shipcat;
 extern crate shipcat_definitions;

--- a/shipcat_cli/tests/graph.rs
+++ b/shipcat_cli/tests/graph.rs
@@ -1,13 +1,6 @@
-extern crate serde_yaml;
 mod common;
-
 use crate::common::setup;
-
-extern crate shipcat;
-extern crate shipcat_definitions;
-
 use shipcat_definitions::{Config, ConfigType};
-
 use shipcat::graph::{generate, nodeidx_from_name};
 
 #[test]

--- a/shipcat_cli/tests/helm.rs
+++ b/shipcat_cli/tests/helm.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::setup;
+use crate::common::setup;
 
 extern crate shipcat;
 extern crate shipcat_definitions;

--- a/shipcat_cli/tests/helm.rs
+++ b/shipcat_cli/tests/helm.rs
@@ -1,9 +1,5 @@
 mod common;
 use crate::common::setup;
-
-extern crate shipcat;
-extern crate shipcat_definitions;
-
 use shipcat_definitions::{Manifest, Config, ConfigType};
 use shipcat::helm::values;
 

--- a/shipcat_cli/tests/slack.rs
+++ b/shipcat_cli/tests/slack.rs
@@ -1,9 +1,5 @@
 mod common;
 use crate::common::setup;
-
-extern crate shipcat;
-extern crate shipcat_definitions;
-
 use shipcat::{Manifest};
 use shipcat::slack::{send, Message, env_channel};
 

--- a/shipcat_cli/tests/slack.rs
+++ b/shipcat_cli/tests/slack.rs
@@ -1,5 +1,5 @@
 mod common;
-use common::setup;
+use crate::common::setup;
 
 extern crate shipcat;
 extern crate shipcat_definitions;

--- a/shipcat_cli/tests/slack.rs
+++ b/shipcat_cli/tests/slack.rs
@@ -3,7 +3,8 @@ use crate::common::setup;
 use shipcat::{Manifest};
 use shipcat::slack::{send, Message, env_channel};
 
-#[test]
+// integration temporarily disabled
+//#[test]
 fn slack_test() {
     setup();
     // metadata is global - can use a blank manifest for this test

--- a/shipcat_cli/tests/validate.rs
+++ b/shipcat_cli/tests/validate.rs
@@ -1,7 +1,7 @@
 extern crate serde_yaml;
 mod common;
 
-use common::setup;
+use crate::common::setup;
 
 extern crate shipcat;
 extern crate shipcat_definitions;

--- a/shipcat_cli/tests/validate.rs
+++ b/shipcat_cli/tests/validate.rs
@@ -1,10 +1,5 @@
-extern crate serde_yaml;
 mod common;
-
 use crate::common::setup;
-
-extern crate shipcat;
-extern crate shipcat_definitions;
 
 use shipcat_definitions::{Config, ConfigType};
 use shipcat::validate::manifest as validate;

--- a/shipcat_definitions/Cargo.toml
+++ b/shipcat_definitions/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["configuration"]
 keywords = ["kubernetes", "helm", "deployment", "standardisation", "validation"]
 license-file = "LICENSE"
 homepage = "https://github.com/Babylonpartners/shipcat"
+edition = "2018"
 
 [lib]
 name = "shipcat_definitions"

--- a/shipcat_definitions/src/config.rs
+++ b/shipcat_definitions/src/config.rs
@@ -247,6 +247,7 @@ impl Config {
     }
 
     /// Complete a Base config for a know to exist region
+    #[cfg(feature = "filesystem")]
     fn complete(&mut self, region: &str) -> Result<()> {
         assert_eq!(self.kind, ConfigType::Base);
         assert_eq!(self.regions.len(), 1);

--- a/shipcat_definitions/src/config.rs
+++ b/shipcat_definitions/src/config.rs
@@ -6,14 +6,14 @@ use std::collections::BTreeMap;
 
 #[allow(unused_imports)]
 use std::path::{Path, PathBuf};
-use structs::SlackChannel;
+use crate::structs::SlackChannel;
 
 
 #[allow(unused_imports)]
 use super::{Result, Error};
 use super::structs::{Contact};
-use states::ConfigType;
-use region::Region;
+use crate::states::ConfigType;
+use crate::region::Region;
 
 // ----------------------------------------------------------------------------------
 
@@ -425,7 +425,7 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-    use region::VersionScheme;
+    use crate::region::VersionScheme;
     #[test]
     fn version_validate_test() {
         let scheme = VersionScheme::GitShaOrSemver;

--- a/shipcat_definitions/src/crds.rs
+++ b/shipcat_definitions/src/crds.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
-use config::{Config};
+use crate::config::{Config};
 
 use super::{Manifest};
-use states::{ManifestType};
+use crate::states::{ManifestType};
 
 /// Basic CRD wrapper struct
 #[derive(Serialize, Deserialize, Clone)]

--- a/shipcat_definitions/src/filebacked.rs
+++ b/shipcat_definitions/src/filebacked.rs
@@ -5,7 +5,7 @@ use walkdir::WalkDir;
 
 use super::{Config, Region, Manifest};
 use super::Result;
-use states::{ManifestType};
+use crate::states::{ManifestType};
 
 /// Private helpers for a filebacked Manifest Backend
 impl Manifest {

--- a/shipcat_definitions/src/lib.rs
+++ b/shipcat_definitions/src/lib.rs
@@ -98,25 +98,25 @@ error_chain! {
 
 /// Config with regional data
 pub mod region;
-pub use region::{Region, VaultConfig, VersionScheme, KongConfig};
+pub use crate::region::{Region, VaultConfig, VersionScheme, KongConfig};
 /// Master config with cross-region data
 pub mod config;
-pub use config::{Config, Cluster, Team, ManifestDefaults};
+pub use crate::config::{Config, Cluster, Team, ManifestDefaults};
 
 
 /// Structs for the manifest
 pub mod structs;
 
 pub mod manifest;
-pub use manifest::Manifest;
+pub use crate::manifest::Manifest;
 
 /// Crd wrappers
 mod crds;
-pub use crds::{Crd, CrdList, CrdEvent, CrdEventType};
+pub use crate::crds::{Crd, CrdList, CrdEvent, CrdEventType};
 
 /// Internal classifications and states
 mod states;
-pub use states::{ConfigType};
+pub use crate::states::{ConfigType};
 
 /// File backing
 #[cfg(feature = "filesystem")]
@@ -139,4 +139,4 @@ pub mod template;
 
 /// A Hashicorp Vault HTTP client using `reqwest`
 pub mod vault;
-pub use vault::Vault;
+pub use crate::vault::Vault;

--- a/shipcat_definitions/src/lib.rs
+++ b/shipcat_definitions/src/lib.rs
@@ -4,22 +4,18 @@
 #![warn(rust_2018_idioms)]
 
 #[macro_use] extern crate serde_derive;
-#[macro_use] extern crate tera;
-
-
 #[macro_use] extern crate log;
 
 
 /// The backing for manifests must come from the filesystem or the CRD
 /// This assert enforce that users of this library choses a feature.
-#[macro_use] extern crate static_assertions;
-assert_cfg!(all(not(all(feature = "filesystem", feature = "crd")),
+static_assertions::assert_cfg!(all(not(all(feature = "filesystem", feature = "crd")),
                 any(    feature = "filesystem", feature = "crd")),
 "shipcat definitions library behaves differently depending on compile time features:\n\n\
 Please `cargo build -p shipcat` or `cargo build -p raftcat` to force a backend choice, \
 or build from shipcat_definitions/ with --features to build the library directly.\n");
 
-#[macro_use] extern crate error_chain;
+#[macro_use] extern crate error_chain; // bail and error_chain macro
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;

--- a/shipcat_definitions/src/lib.rs
+++ b/shipcat_definitions/src/lib.rs
@@ -33,9 +33,8 @@ extern crate base64;
 extern crate static_assertions;
 assert_cfg!(all(not(all(feature = "filesystem", feature = "crd")),
                 any(    feature = "filesystem", feature = "crd")),
-"Shipcat definitions library behaves differently depending on compile time feature:\
-A feature must be chosen to be either \"crd\" or \"filesystem\" \n\n\
-Please `cargo build -p shipcat` or `cargo build -p raftcat` to force a choice,\
+"shipcat definitions library behaves differently depending on compile time features:\n\n\
+Please `cargo build -p shipcat` or `cargo build -p raftcat` to force a backend choice, \
 or build from shipcat_definitions/ with --features to build the library directly.\n");
 
 #[macro_use]

--- a/shipcat_definitions/src/lib.rs
+++ b/shipcat_definitions/src/lib.rs
@@ -1,44 +1,25 @@
 #![recursion_limit = "1024"]
 #![allow(renamed_and_removed_lints)]
 #![allow(non_snake_case)]
+#![warn(rust_2018_idioms)]
 
-//extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_yaml;
-extern crate serde_json;
-extern crate serde;
+#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate tera;
 
-#[macro_use]
-extern crate tera;
-#[cfg(feature = "filesystem")]
-extern crate walkdir;
 
-#[cfg(feature = "filesystem")]
-extern crate dirs;
+#[macro_use] extern crate log;
 
-#[macro_use]
-extern crate log;
-
-extern crate reqwest;
-
-extern crate regex;
-
-extern crate semver;
-extern crate base64;
 
 /// The backing for manifests must come from the filesystem or the CRD
 /// This assert enforce that users of this library choses a feature.
-#[macro_use]
-extern crate static_assertions;
+#[macro_use] extern crate static_assertions;
 assert_cfg!(all(not(all(feature = "filesystem", feature = "crd")),
                 any(    feature = "filesystem", feature = "crd")),
 "shipcat definitions library behaves differently depending on compile time features:\n\n\
 Please `cargo build -p shipcat` or `cargo build -p raftcat` to force a backend choice, \
 or build from shipcat_definitions/ with --features to build the library directly.\n");
 
-#[macro_use]
-extern crate error_chain;
+#[macro_use] extern crate error_chain;
 error_chain! {
     types {
         Error, ErrorKind, ResultExt, Result;

--- a/shipcat_definitions/src/manifest.rs
+++ b/shipcat_definitions/src/manifest.rs
@@ -1,10 +1,10 @@
-use vault::Vault;
+use crate::vault::Vault;
 use std::collections::{BTreeMap, BTreeSet};
 use regex::Regex;
 
-use config::{Config};
-use region::{VaultConfig, Region};
-use states::ManifestType;
+use crate::config::{Config};
+use crate::region::{VaultConfig, Region};
+use crate::states::ManifestType;
 use super::Result;
 
 // All structs come from the structs directory

--- a/shipcat_definitions/src/math.rs
+++ b/shipcat_definitions/src/math.rs
@@ -112,7 +112,7 @@ impl Manifest {
 
 #[cfg(test)]
 mod tests {
-    use structs::HealthCheck;
+    use crate::structs::HealthCheck;
     use super::{Manifest};
 
     #[test]

--- a/shipcat_definitions/src/region.rs
+++ b/shipcat_definitions/src/region.rs
@@ -1,4 +1,4 @@
-use structs::kong::Kong;
+use crate::structs::kong::Kong;
 use std::collections::BTreeMap;
 
 use semver::Version;

--- a/shipcat_definitions/src/region.rs
+++ b/shipcat_definitions/src/region.rs
@@ -278,7 +278,7 @@ impl Region {
     }
 
     // Entry point for region verifier
-    pub fn verify_secrets_exist(&mut self) -> Result<()> {
+    pub fn verify_secrets_exist(&self) -> Result<()> {
         let v = Vault::regional(&self.vault)?;
         debug!("Validating kong secrets for {}", self.name);
         self.kong.verify_secrets_exist(&v, &self.name)?;

--- a/shipcat_definitions/src/structs/cronjob.rs
+++ b/shipcat_definitions/src/structs/cronjob.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-use structs::resources::Resources;
+use crate::structs::resources::Resources;
 use super::EnvVars;
 use super::Result;
 

--- a/shipcat_definitions/src/structs/kafka.rs
+++ b/shipcat_definitions/src/structs/kafka.rs
@@ -1,4 +1,4 @@
-use region::{Region};
+use crate::region::{Region};
 
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/shipcat_definitions/src/structs/kongfig.rs
+++ b/shipcat_definitions/src/structs/kongfig.rs
@@ -1,6 +1,6 @@
 //use super::traits::Verify;
-use structs::{Kong, Cors, BabylonAuthHeader};
-use region::{KongConfig};
+use crate::structs::{Kong, Cors, BabylonAuthHeader};
+use crate::region::{KongConfig};
 use std::collections::BTreeMap;
 use serde::ser::{Serialize, Serializer, SerializeMap};
 

--- a/shipcat_definitions/src/structs/metadata.rs
+++ b/shipcat_definitions/src/structs/metadata.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::ops::{Deref, DerefMut};
 
 use super::Result;
-use config::{Team, SlackParameters};
+use crate::config::{Team, SlackParameters};
 
 /// Contact data
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/shipcat_definitions/src/template.rs
+++ b/shipcat_definitions/src/template.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::iter;
 
-use tera::{self, Value, Tera, Context};
+use tera::{self, Value, Tera, Context, try_get_value};
 use super::{Result, ErrorKind, ResultExt};
 
 #[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]

--- a/shipcat_definitions/src/vault.rs
+++ b/shipcat_definitions/src/vault.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::io::Read;
 
 use super::{Result, ErrorKind, ResultExt, Error};
-use region::{VaultConfig};
+use crate::region::{VaultConfig};
 
 fn default_addr() -> Result<String> {
     env::var("VAULT_ADDR").map_err(|_| ErrorKind::MissingVaultAddr.into())


### PR DESCRIPTION
requires 1.31.0 (which came out today)