### PR TITLE
let slack notifications go to notification channels - fixes #32

### DIFF
--- a/shipcat_cli/src/get.rs
+++ b/shipcat_cli/src/get.rs
@@ -13,10 +13,8 @@ use super::{Result, Manifest};
 ///
 /// Services without a hardcoded version are not returned.
 pub fn versions(conf: &Config, region: &Region) -> Result<BTreeMap<String, Version>> {
-    let services = Manifest::available(&region.name)?;
     let mut output = BTreeMap::new();
-
-    for svc in services {
+    for svc in Manifest::available(&region.name)? {
         let mf = Manifest::simple(&svc, &conf, &region)?;
         if let Some(v) = mf.version {
             if let Ok(sv) = Version::parse(&v) {
@@ -32,9 +30,8 @@ pub fn versions(conf: &Config, region: &Region) -> Result<BTreeMap<String, Versi
 ///
 /// Services without a hardcoded image will assume the shipcat.conf specific default
 pub fn images(conf: &Config, region: &Region) -> Result<BTreeMap<String, String>> {
-    let services = Manifest::available(&region.name)?;
     let mut output = BTreeMap::new();
-    for svc in services {
+    for svc in Manifest::available(&region.name)? {
         // NB: needs > raw version of manifests because we need image implicits..
         let mf = Manifest::simple(&svc, &conf, &region)?;
         if let Some(i) = mf.image {
@@ -50,10 +47,8 @@ pub fn images(conf: &Config, region: &Region) -> Result<BTreeMap<String, String>
 /// Cross references config.teams with manifest.metadata.team
 /// Each returned string is Github CODEOWNER syntax
 pub fn codeowners(conf: &Config) -> Result<Vec<String>> {
-    let services = Manifest::all()?;
     let mut output = vec![];
-
-    for svc in services {
+    for svc in Manifest::all()? {
         // Can rely on blank here because metadata is a global property
         let mf = Manifest::blank(&svc)?;
         if let Some(md) = mf.metadata {

--- a/shipcat_cli/src/kube.rs
+++ b/shipcat_cli/src/kube.rs
@@ -508,7 +508,7 @@ mod tests {
         // ignoring this test on circleci..
         if kubecfg.is_file() {
             let ctx = current_context().unwrap();
-            assert_eq!(ctx, "dev-uk".to_string());
+            assert_eq!(ctx, "devuk-green".to_string());
         }
     }
 }

--- a/shipcat_cli/src/webhooks.rs
+++ b/shipcat_cli/src/webhooks.rs
@@ -27,7 +27,7 @@ pub enum UpgradeState {
 
 pub fn ensure_requirements(reg: &Region) -> Result<()> {
     if let Some(whs) = &reg.webhooks {
-        for wh in whs.iter() {
+        for wh in whs {
             wh.get_configuration()?;
         }
     }
@@ -39,7 +39,7 @@ pub fn ensure_requirements(reg: &Region) -> Result<()> {
 /// Http errors are NOT propagated from here
 pub fn reconcile_event(us: UpgradeState, reg: &Region) {
     if let Some(whs) = &reg.webhooks {
-        for wh in whs.iter() {
+        for wh in whs {
             if let Ok(whc) = wh.get_configuration() {
                 if let Err(e) = match wh {
                     Webhook::Audit(h) => {
@@ -72,9 +72,9 @@ pub fn upgrade_event(us: UpgradeState, ud: &UpgradeData, reg: &Region) {
 }
 
 /// Notify slack / audit endpoint of upgrades from a single upgrade
-pub fn handle_upgrade_notifies(us: UpgradeState, ud: &UpgradeData, reg: &Region) {
+fn handle_upgrade_notifies(us: UpgradeState, ud: &UpgradeData, reg: &Region) {
     if let Some(whs) = &reg.webhooks {
-        for wh in whs.iter() {
+        for wh in whs {
             if let Ok(whc) = wh.get_configuration() {
                 if let Err(e) = match wh {
                     Webhook::Audit(h) => {
@@ -124,7 +124,7 @@ pub fn handle_upgrade_notifies(us: UpgradeState, ud: &UpgradeData, reg: &Region)
 /// Http errors are NOT propagated from here
 pub fn upgrade_rollback_event(us: UpgradeState, ud: &UpgradeData, reg: &Region) {
     if let Some(whs) = &reg.webhooks {
-        for wh in whs.iter() {
+        for wh in whs {
             if let Ok(whc) = wh.get_configuration() {
                 if let Err(e) = match wh {
                     Webhook::Audit(h) => {

--- a/shipcat_cli/tests/common.rs
+++ b/shipcat_cli/tests/common.rs
@@ -48,9 +48,8 @@ fn config_test() {
     assert!(Config::read().is_ok());
     assert!(Config::new(ConfigType::Base, "dev-uk").is_ok());
     let fullcfg = Config::new(ConfigType::Completed, "dev-uk");
-    assert!(fullcfg.is_ok());
+    let (conf, _region) = fullcfg.unwrap(); // better to unwrap and get full trace
     assert!(Config::new(ConfigType::File, "dev-uk").is_err());
-    let (conf, _region) = fullcfg.unwrap();
     assert!(conf.print().is_ok());
 }
 

--- a/tests/shipcat.conf
+++ b/tests/shipcat.conf
@@ -58,7 +58,7 @@ regions:
   webhooks:
     - name: audit
       url: http://testserver/shipcat
-      token: IN_VAULT
+      token: secretsauce
 
 - name: dev-global
   namespace: dev


### PR DESCRIPTION
technically doubling the notifications atm, because it also goes to the configured evar channel, but good migration start