### PR TITLE
New upgrade option: --no-wait

### DIFF
--- a/shipcat_cli/src/helm/direct.rs
+++ b/shipcat_cli/src/helm/direct.rs
@@ -44,8 +44,8 @@ impl fmt::Display for UpgradeMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             &UpgradeMode::DiffOnly => write!(f, "diff"),
-            &UpgradeMode::UpgradeWait => write!(f, "blindly upgrade"),
-            &UpgradeMode::UpgradeNoWait => write!(f, "blindly upgrade (no wait)"),
+            &UpgradeMode::UpgradeWait => write!(f, "upgrade"),
+            &UpgradeMode::UpgradeNoWait => write!(f, "upgrade (fire and forget)"),
             &UpgradeMode::UpgradeRecreateWait => write!(f, "recreate"),
             &UpgradeMode::UpgradeInstall => write!(f, "install"),
             &UpgradeMode::UpgradeWaitMaybeRollback => write!(f, "upgrade"),
@@ -59,8 +59,8 @@ impl UpgradeMode {
     pub fn action_verb(&self) -> String {
         match self {
             &UpgradeMode::DiffOnly => "diffed",
-            &UpgradeMode::UpgradeWait => "blindly upgraded",
-            &UpgradeMode::UpgradeNoWait => "blindly upgraded (no wait)",
+            &UpgradeMode::UpgradeWait => "upgraded",
+            &UpgradeMode::UpgradeNoWait => "upgraded (fire and forget)",
             &UpgradeMode::UpgradeRecreateWait => "recreated pods for",
             &UpgradeMode::UpgradeInstall => "installed",
             &UpgradeMode::UpgradeWaitMaybeRollback => "upgraded",

--- a/shipcat_cli/src/main.rs
+++ b/shipcat_cli/src/main.rs
@@ -70,6 +70,9 @@ fn main() {
                 .about("Recreate pods and reconcile helm config for a service"))
             .subcommand(SubCommand::with_name("upgrade")
                 .about("Upgrade a helm release from a manifest")
+                .arg(Arg::with_name("no-wait")
+                    .long("no-wait")
+                    .help("Do not wait for service timeout"))
                 .arg(Arg::with_name("auto-rollback")
                     .long("auto-rollback"))
                 .arg(Arg::with_name("dryrun")
@@ -642,6 +645,9 @@ fn dispatch_commands(args: &ArgMatches) -> Result<()> {
             }
             else if b.is_present("auto-rollback") {
                 shipcat::helm::UpgradeMode::UpgradeWaitMaybeRollback
+            }
+            else if b.is_present("no-wait") {
+                shipcat::helm::UpgradeMode::UpgradeNoWait
             }
             else {
                 shipcat::helm::UpgradeMode::UpgradeWait


### PR DESCRIPTION
Allows us to tell Helm to upgrade a deployment, and not wait for
anything. The deployment may fail or succeed eventually, we just won't
wait for it.