### PR TITLE
[IDM-88] Add support for Kong JWT consumers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.yaml]
+indent_size = 2
+
+[shipcat.conf]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/shipcat_cli/tests/common.rs
+++ b/shipcat_cli/tests/common.rs
@@ -216,14 +216,29 @@ fn kong_test() {
 
     assert_eq!(output.host, "admin.dev.something.domain.com");
 
-    assert_eq!(output.consumers.len(), 2);
+    assert_eq!(output.consumers.len(), 3);
     assert_eq!(output.consumers[0].username, "fake-ask");
     assert_eq!(output.consumers[0].credentials.len(), 1);
-    let kongfig::ConsumerCredentials::OAuth2(attrs) = &output.consumers[0].credentials[0];
-    assert_eq!(attrs.client_id, "FAKEASKID");
-    assert_eq!(attrs.client_secret, "FAKEASKSECRET");
+    if let kongfig::ConsumerCredentials::OAuth2(attrs) = &output.consumers[0].credentials[0] {
+        assert_eq!(attrs.client_id, "FAKEASKID");
+        assert_eq!(attrs.client_secret, "FAKEASKSECRET");
+    } else {
+        panic!("Not an OAuth2 credential")
+    }
 
-    assert_eq!(output.consumers[1].username, "anonymous");
+    assert_eq!(output.consumers[1].username, "my-idp");
+    assert_eq!(output.consumers[1].credentials.len(), 1);
+    if let kongfig::ConsumerCredentials::Jwt(attrs) = &output.consumers[1].credentials[0] {
+        assert_eq!(attrs.key, "https://my-issuer/");
+        assert_eq!(attrs.algorithm, "RS256");
+        assert_eq!(attrs.rsa_public_key, "-----BEGIN PUBLIC KEY-----\nmy-key\n-----END PUBLIC KEY-----");
+    } else {
+        panic!("Not a JWT credential")
+    }
+
+    assert_eq!(output.consumers[2].username, "anonymous");
+    assert!(output.consumers[2].credentials.is_empty());
+
 
     assert_eq!(output.apis.len(), 1);
     let api = &output.apis[0];

--- a/shipcat_cli/tests/common.rs
+++ b/shipcat_cli/tests/common.rs
@@ -219,10 +219,9 @@ fn kong_test() {
     assert_eq!(output.consumers.len(), 2);
     assert_eq!(output.consumers[0].username, "fake-ask");
     assert_eq!(output.consumers[0].credentials.len(), 1);
-    let creds = &output.consumers[0].credentials[0];
-    assert_eq!(creds.name, "oauth2");
-    assert_eq!(creds.attributes.client_id, "FAKEASKID");
-    assert_eq!(creds.attributes.client_secret, "FAKEASKSECRET");
+    let kongfig::ConsumerCredentials::OAuth2(attrs) = &output.consumers[0].credentials[0];
+    assert_eq!(attrs.client_id, "FAKEASKID");
+    assert_eq!(attrs.client_secret, "FAKEASKSECRET");
 
     assert_eq!(output.consumers[1].username, "anonymous");
 

--- a/shipcat_definitions/src/region.rs
+++ b/shipcat_definitions/src/region.rs
@@ -125,6 +125,8 @@ pub struct KongConfig {
     pub anonymous_consumers: Option<KongAnonymousConsumers>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub consumers: BTreeMap<String, KongOauthConsumer>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub jwt_consumers: BTreeMap<String, KongJwtConsumer>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub internal_ips_whitelist: Vec<String>,
     #[serde(default, skip_serializing)]
@@ -183,6 +185,13 @@ pub struct KongOauthConsumer {
     pub oauth_client_id: String,
     pub oauth_client_secret: String,
     pub username: String
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct KongJwtConsumer {
+    pub issuer: String,
+    pub public_key: String,
 }
 
 impl KongConfig {

--- a/shipcat_definitions/src/structs/kongfig.rs
+++ b/shipcat_definitions/src/structs/kongfig.rs
@@ -512,7 +512,7 @@ pub struct Consumer {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(tag = "name", content = "attributes")]
+#[serde(tag = "name", content = "attributes", rename_all="kebab-case")]
 pub enum ConsumerCredentials {
     #[serde(rename = "oauth2")]
     OAuth2(OAuth2CredentialsAttributes),

--- a/shipcat_definitions/src/structs/kongfig.rs
+++ b/shipcat_definitions/src/structs/kongfig.rs
@@ -472,15 +472,12 @@ pub fn kongfig_consumers(k: KongConfig) -> Vec<Consumer> {
         Consumer {
             username: k.to_string(),
             acls: vec![],
-            credentials: vec![ConsumerCredentials {
-                name: "oauth2".into(),
-                attributes: ConsumerCredentialsAttributes {
-                    name: v.username,
-                    client_id: v.oauth_client_id,
-                    client_secret: v.oauth_client_secret,
-                    redirect_uri: vec!["http://example.com/unused".into()]
-                }
-            }],
+            credentials: vec![ConsumerCredentials::OAuth2(OAuth2CredentialsAttributes {
+                name: v.username,
+                client_id: v.oauth_client_id,
+                client_secret: v.oauth_client_secret,
+                redirect_uri: vec!["http://example.com/unused".into()]
+            })],
         }
     }).collect();
 
@@ -503,15 +500,15 @@ pub struct Consumer {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(deny_unknown_fields)]
-pub struct ConsumerCredentials {
-    pub name: String,
-    pub attributes: ConsumerCredentialsAttributes,
+#[serde(tag = "name", content = "attributes")]
+pub enum ConsumerCredentials {
+    #[serde(rename = "oauth2")]
+    OAuth2(OAuth2CredentialsAttributes),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
-pub struct ConsumerCredentialsAttributes {
+pub struct OAuth2CredentialsAttributes {
     pub client_id: String,
     pub redirect_uri: Vec<String>,
     pub name: String,

--- a/shipcat_definitions/src/structs/kongfig.rs
+++ b/shipcat_definitions/src/structs/kongfig.rs
@@ -481,6 +481,18 @@ pub fn kongfig_consumers(k: KongConfig) -> Vec<Consumer> {
         }
     }).collect();
 
+    k.jwt_consumers.into_iter().map(|(k,v)| {
+        Consumer {
+            username: k.to_string(),
+            acls: vec![],
+            credentials: vec![ConsumerCredentials::Jwt(JwtCredentialsAttributes {
+                key: v.issuer,
+                algorithm: "RS256".into(),
+                rsa_public_key: v.public_key,
+            })]
+        }
+    }).for_each(|c| consumers.push(c));
+
     // Add the anonymous customer as well
     consumers.push(Consumer {
         username: "anonymous".into(),
@@ -504,6 +516,7 @@ pub struct Consumer {
 pub enum ConsumerCredentials {
     #[serde(rename = "oauth2")]
     OAuth2(OAuth2CredentialsAttributes),
+    Jwt(JwtCredentialsAttributes),
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -515,6 +528,13 @@ pub struct OAuth2CredentialsAttributes {
     pub client_secret: String,
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct JwtCredentialsAttributes {
+    pub algorithm: String,
+    pub key: String,
+    pub rsa_public_key: String,
+}
 
 /// Not used yet
 #[derive(Serialize, Deserialize, Clone, Default)]

--- a/tests/shipcat.conf
+++ b/tests/shipcat.conf
@@ -48,6 +48,13 @@ regions:
         oauth_client_id: "FAKEASKID"
         oauth_client_secret: "FAKEASKSECRET"
         username: "fake-ask"
+    jwt_consumers:
+      my-idp:
+        issuer: https://my-issuer/
+        public_key: |-
+          -----BEGIN PUBLIC KEY-----
+          my-key
+          -----END PUBLIC KEY-----
     tcp_log:
       enabled: true
       host: "logstash-kong-metrics.ops.svc.cluster.local"


### PR DESCRIPTION
Converts this:
```yaml
# shipcat.conf
regions:
- kong:
    jwt_consumers:
      my-consumer:
        issuer: https://my-issuer/
        public_key: |-
          -----BEGIN PUBLIC KEY-----
          ...
          -----END PUBLIC KEY-----
```

Into this:
```yaml
# Output of `shipcat kong`
consumers:
  - username: my-consumer
    credentials:
      - name: jwt
        attributes:
          algorithm: RS256
          key: https://my-issuer/
          rsa_public_key: |-
            -----BEGIN PUBLIC KEY-----
            ...
            -----END PUBLIC KEY-----
```

(part of #60)

# Testing
I've compared the output of `shipcat kong` (0.81.0) using  with `cargo run kong` against `master` of the manifests repo, which makes no changes.

Also see https://github.com/Babylonpartners/manifests/pull/4675 for an example of a JWT consumer and the Kong diff.