### PR TITLE
elasticache provisioning + reducers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "raftcat"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "actix 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-web 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1303,7 +1303,7 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "shipcat_definitions 0.83.0",
+ "shipcat_definitions 0.84.0",
  "tera 0.11.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1641,7 +1641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "shipcat"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1660,7 +1660,7 @@ dependencies = [
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "shipcat_definitions 0.83.0",
+ "shipcat_definitions 0.84.0",
  "slack-hook 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "shipcat_definitions"
-version = "0.83.0"
+version = "0.84.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/shipcat_cli/shipcat.complete.sh
+++ b/shipcat_cli/shipcat.complete.sh
@@ -58,7 +58,7 @@ _shipcat()
                 COMPREPLY=($(compgen -W "$svcs" -- "$cur"))
                 ;;
             get)
-                COMPREPLY=($(compgen -W "versions databases resources images clusterinfo vault-url apistatus codeowners" -- "$cur"))
+                COMPREPLY=($(compgen -W "versions databases caches resources images clusterinfo vault-url apistatus codeowners" -- "$cur"))
                 ;;
             apply|template|values|status|crd)
                 local -r region="$(kubectl config current-context)"

--- a/shipcat_cli/src/get.rs
+++ b/shipcat_cli/src/get.rs
@@ -2,7 +2,10 @@
 use std::collections::BTreeMap;
 use semver::Version;
 
-use crate::structs::rds::Rds;
+use crate::structs::{
+    rds::Rds,
+    elasticache::ElastiCache,
+};
 use super::{Config, Team, Region};
 use super::{Result, Manifest};
 
@@ -204,6 +207,23 @@ pub fn databases(conf: &Config, region: &Region) -> Result<Vec<Rds>> {
     }
     println!("{}", serde_yaml::to_string(&dbs)?);
     Ok(dbs)
+}
+
+/// Find the ElastiCache instances to be provisioned for a region
+///
+/// Reduces all manifests in a region and produces a list for a terraform component
+/// to act on.
+pub fn caches(conf: &Config, region: &Region) -> Result<Vec<ElastiCache>> {
+    let mut caches = Vec::new();
+    for svc in Manifest::available(&region.name)? {
+        // NB: needs > raw version of manifests because we need image implicits..
+        let mf = Manifest::simple(&svc, &conf, &region)?;
+        if let Some(db) = mf.redis {
+            caches.push(db);
+        }
+    }
+    println!("{}", serde_yaml::to_string(&caches)?);
+    Ok(caches)
 }
 
 // ----------------------------------------------------------------------------

--- a/shipcat_cli/src/main.rs
+++ b/shipcat_cli/src/main.rs
@@ -170,6 +170,8 @@ fn main() {
                 .help("Reduce encoded image info"))
               .subcommand(SubCommand::with_name("databases")
                 .help("Reduce encoded databases"))
+              .subcommand(SubCommand::with_name("caches")
+                .help("Reduce encoded redis caches"))
               .subcommand(SubCommand::with_name("resources")
                 .help("Reduce encoded resouce requests and limits"))
               .subcommand(SubCommand::with_name("apistatus")
@@ -463,6 +465,9 @@ fn dispatch_commands(args: &ArgMatches) -> Result<()> {
         }
         if let Some(_) = a.subcommand_matches("databases") {
             return shipcat::get::databases(&conf, &region).map(void);
+        }
+        if let Some(_) = a.subcommand_matches("caches") {
+            return shipcat::get::caches(&conf, &region).map(void);
         }
         if let Some(_) = a.subcommand_matches("codeowners") {
             return shipcat::get::codeowners(&conf).map(void);

--- a/shipcat_definitions/src/manifest.rs
+++ b/shipcat_definitions/src/manifest.rs
@@ -8,22 +8,25 @@ use crate::states::ManifestType;
 use super::Result;
 
 // All structs come from the structs directory
-use super::structs::{HealthCheck, ConfigMap};
-use super::structs::{InitContainer, Resources, HostAlias};
-use super::structs::volume::{Volume, VolumeMount};
-use super::structs::PersistentVolume;
-use super::structs::{Metadata, VaultOpts, Dependency};
-use super::structs::security::DataHandling;
-use super::structs::Probe;
-use super::structs::{CronJob, Sidecar, EnvVars};
-use super::structs::{Gate, Kafka, Kong, Rbac};
-use super::structs::RollingUpdate;
-use super::structs::autoscaling::AutoScaling;
-use super::structs::tolerations::Tolerations;
-use super::structs::LifeCycle;
-use super::structs::Worker;
-use super::structs::Port;
-use super::structs::rds::Rds;
+use super::structs::{
+    {HealthCheck, ConfigMap},
+    {InitContainer, Resources, HostAlias},
+    volume::{Volume, VolumeMount},
+    PersistentVolume,
+    {Metadata, VaultOpts, Dependency},
+    security::DataHandling,
+    Probe,
+    {CronJob, Sidecar, EnvVars},
+    {Gate, Kafka, Kong, Rbac},
+    RollingUpdate,
+    autoscaling::AutoScaling,
+    tolerations::Tolerations,
+    LifeCycle,
+    Worker,
+    Port,
+    rds::Rds,
+    elasticache::ElastiCache,
+};
 
 /// Main manifest, serializable from shipcat.yml or the shipcat CRD.
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -681,12 +684,25 @@ pub struct Manifest {
     ///
     /// Set the base parameters for an RDS instance.
     ///
+    /// ```yaml
     /// database:
     ///   engine: postgres
     ///   version: 9.6
     ///   size: 20
     ///   instanceClass: "db.m4.large"
+    /// ```
     pub database: Option<Rds>,
+
+    /// Redis provisioning sent to terraform
+    ///
+    /// Set the base parameters for an ElastiCache instance
+    ///
+    /// ```yaml
+    /// redis:
+    ///   nodes: 2
+    ///   nodeType: cache.m4.large
+    /// ```
+    pub redis: Option<ElastiCache>,
 
     // ------------------------------------------------------------------------
     // Output variables
@@ -892,6 +908,9 @@ impl Manifest {
         }
         if let Some(db) = &self.database {
             db.verify()?;
+        }
+        if let Some(redis) = &self.redis {
+            redis.verify()?;
         }
 
         Ok(())

--- a/shipcat_definitions/src/merge.rs
+++ b/shipcat_definitions/src/merge.rs
@@ -25,10 +25,14 @@ impl Manifest {
             // dataHandling has cascading encryption values
             dh.implicits();
         }
+        // infrastructure uses service name as database name
+        // it also passes on the team from metadata:
+        let md = self.metadata.clone().unwrap(); // exists by merge_and_fill_defaults
         if let Some(ref mut db) = self.database {
-            // databases use service name as database name - and pass on team from metadata
-            let md = self.metadata.clone().unwrap(); // exists by merge_and_fill_defaults
             db.implicits(&self.name, &md);
+        }
+        if let Some(ref mut redis) = self.redis {
+            redis.implicits(&self.name, &md);
         }
 
         // Inject the region's environment name and namespace
@@ -149,6 +153,9 @@ impl Manifest {
         }
         if mf.database.is_some() {
             self.database = mf.database;
+        }
+        if mf.redis.is_some() {
+            self.redis = mf.redis;
         }
         if mf.vault.is_some() {
             self.vault = mf.vault;

--- a/shipcat_definitions/src/structs/elasticache.rs
+++ b/shipcat_definitions/src/structs/elasticache.rs
@@ -8,25 +8,36 @@ use super::Metadata;
 /// ElastiCache Node Types
 ///
 /// Subset of the official [AWS ElastiCache node type list](https://aws.amazon.com/elasticache/pricing/).
+/// Only current generation (m5 + r5) + along with cheap t2 nodes
 #[derive(Deserialize, Serialize, Clone)]
 pub enum NodeType {
+    // Standard t2 nodes
     #[serde(rename = "cache.t2.micro")]
-    CacheT2Micro,
-
+    CacheT2micro,
     #[serde(rename = "cache.t2.small")]
-    CacheT2Small,
-
+    CacheT2small,
     #[serde(rename = "cache.t2.medium")]
-    CacheT2Medium,
+    CacheT2medium,
 
-    #[serde(rename = "cache.m4.large")]
-    CacheM4Large,
+    // Standard m5
+    #[serde(rename = "cache.m5.large")]
+    CacheM5large,
+    #[serde(rename = "cache.m5.xlarge")]
+    CacheM5xlarge,
+    #[serde(rename = "cache.m5.2xlarge")]
+    CacheM52xlarge,
+    #[serde(rename = "cache.m5.4xlarge")]
+    CacheM54xlarge,
 
-    #[serde(rename = "cache.m4.xlarge")]
-    CacheM4Xlarge,
-
-    #[serde(rename = "cache.r4.large")]
-    CacheR4Large,
+    // Memory optimized
+    #[serde(rename = "cache.r5.large")]
+    CacheR5large,
+    #[serde(rename = "cache.r5.xlarge")]
+    CacheR5xlarge,
+    #[serde(rename = "cache.r5.2xlarge")]
+    CacheR52xlarge,
+    #[serde(rename = "cache.r5.4xlarge")]
+    CacheR54xlarge,
 }
 
 /// AWS ElastiCache parameters for infrastructure provisioning

--- a/shipcat_definitions/src/structs/elasticache.rs
+++ b/shipcat_definitions/src/structs/elasticache.rs
@@ -1,0 +1,80 @@
+//! Minimal abstraction around aws elasticache
+//! Supports redis with cluster mode disabled (single shard - up to 5 read replicas)
+//! https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.Redis-RedisCluster.html
+
+use super::Result;
+use super::Metadata;
+
+/// ElastiCache Node Types
+///
+/// Subset of the official [AWS ElastiCache node type list](https://aws.amazon.com/elasticache/pricing/).
+#[derive(Deserialize, Serialize, Clone)]
+pub enum NodeType {
+    #[serde(rename = "cache.t2.micro")]
+    CacheT2Micro,
+
+    #[serde(rename = "cache.t2.small")]
+    CacheT2Small,
+
+    #[serde(rename = "cache.t2.medium")]
+    CacheT2Medium,
+
+    #[serde(rename = "cache.m4.large")]
+    CacheM4Large,
+
+    #[serde(rename = "cache.m4.xlarge")]
+    CacheM4Xlarge,
+
+    #[serde(rename = "cache.r4.large")]
+    CacheR4Large,
+}
+
+/// AWS ElastiCache parameters for infrastructure provisioning
+///
+/// Simplified input for configuring a single instance Redis for your service.
+/// Based loosely on the inputs from:
+/// - [aws elasticache cluster replication](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.Redis-RedisCluster.html)
+/// - [aws elasticache cluster replication groups](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Replication.CreatingReplGroup.ExistingCluster.html)
+/// - [terraform aws_elasticache_replication_group](https://www.terraform.io/docs/providers/aws/r/elasticache_replication_group.html)
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ElastiCache {
+    /// Name of service (filled from manifest name)
+    #[serde(skip_deserializing)]
+    pub name: Option<String>,
+
+    /// Name of team owning the service (filled from manifest)
+    #[serde(skip_deserializing)]
+    pub team: Option<String>,
+
+    /// Number of nodes (master + read replicas)
+    ///
+    /// Sometimes referred to as num cache clusters (in cluster mode disabled).
+    /// This number includes the master/shard.
+    ///
+    /// Must be between an integer `1` and `6`.
+    pub nodes: Option<u8>,
+
+    /// The node type of the ElastiCache instance
+    ///
+    /// Defaults to cache.m4.large
+    pub nodeType: Option<NodeType>,
+}
+
+impl ElastiCache {
+    pub fn verify(&self) -> Result<()> {
+        let num = self.nodes.unwrap(); // must exist by implicits
+        if num < 1 {
+            bail!("Need at least 1 node (cluster includes the master)")
+        }
+        if num > 6 {
+            bail!("Need less than 6 nodes (non-cluster mode has max 5 read replicas)")
+        }
+        Ok(())
+    }
+
+    pub fn implicits(&mut self, svc: &str, md: &Metadata) {
+        // caches named after services
+        self.name = Some(svc.into());
+        self.team = Some(md.team.clone());
+    }
+}

--- a/shipcat_definitions/src/structs/elasticache.rs
+++ b/shipcat_definitions/src/structs/elasticache.rs
@@ -11,7 +11,7 @@ use super::Metadata;
 /// Only current generation (m5 + r5) + along with cheap t2 nodes
 #[derive(Deserialize, Serialize, Clone)]
 pub enum NodeType {
-    // Standard t2 nodes
+    // Cheap t2 nodes
     #[serde(rename = "cache.t2.micro")]
     CacheT2micro,
     #[serde(rename = "cache.t2.small")]
@@ -19,7 +19,7 @@ pub enum NodeType {
     #[serde(rename = "cache.t2.medium")]
     CacheT2medium,
 
-    // Standard m5
+    // General purpose m5
     #[serde(rename = "cache.m5.large")]
     CacheM5large,
     #[serde(rename = "cache.m5.xlarge")]

--- a/shipcat_definitions/src/structs/elasticache.rs
+++ b/shipcat_definitions/src/structs/elasticache.rs
@@ -56,7 +56,7 @@ pub struct ElastiCache {
 
     /// The node type of the ElastiCache instance
     ///
-    /// Defaults to cache.m4.large
+    /// E.g. cache.m4.large
     pub nodeType: Option<NodeType>,
 }
 

--- a/shipcat_definitions/src/structs/mod.rs
+++ b/shipcat_definitions/src/structs/mod.rs
@@ -103,3 +103,5 @@ pub use self::persistentvolume::PersistentVolume;
 
 /// AWS RDS
 pub mod rds;
+/// AWS ElastiCache
+pub mod elasticache;

--- a/shipcat_definitions/src/structs/rds.rs
+++ b/shipcat_definitions/src/structs/rds.rs
@@ -73,7 +73,7 @@ pub struct Rds {
 
     /// The instance type of the RDS instance
     ///
-    /// Defaults to db.m4.large
+    /// E.g. db.m4.large
     pub instanceClass: Option<InstanceClass>,
 
     // TODO: allow customizing backup setup?

--- a/shipcat_definitions/src/structs/rds.rs
+++ b/shipcat_definitions/src/structs/rds.rs
@@ -43,12 +43,6 @@ pub enum InstanceClass {
 // TODO: pr to serde for extra case rename type?
 // https://github.com/serde-rs/serde/blob/7950f3cdc52d4898aa4195b853cbec12d65bb091/serde_derive/src/internals/case.rs
 
-// TODO: maybe force this explicit?
-// this was a standard.
-impl Default for InstanceClass {
-    fn default() -> Self { InstanceClass::DbM4Large }
-}
-
 /// AWS RDS parameters for infrastructure provisioning
 ///
 /// Simplified input for configuring a database for your service.
@@ -107,6 +101,5 @@ impl Rds {
         // databases named after services
         self.name = Some(svc.into());
         self.team = Some(md.team.clone());
-        self.instanceClass = Some(InstanceClass::default());
     }
 }

--- a/shipcat_definitions/src/structs/rds.rs
+++ b/shipcat_definitions/src/structs/rds.rs
@@ -14,29 +14,42 @@ pub enum RdsEngine {
 /// RDS Instance types
 ///
 /// Subset of the official [AWS RDS instance type list](https://aws.amazon.com/rds/instance-types/).
+/// Current gen (m5 + t3) along with older m4 + t2.
 #[derive(Deserialize, Serialize, Clone)]
 pub enum InstanceClass {
+    // Burstable T2 instances for compat
+    #[serde(rename = "db.t2.micro")]
+    DbT2micro,
+    #[serde(rename = "db.t2.small")]
+    DbT2small,
     #[serde(rename = "db.t2.medium")]
-    DbT2Medium,
+    DbT2medium,
 
+    // Burstable T3 instance
+    #[serde(rename = "db.t3.micro")]
+    DbT3micro,
+    #[serde(rename = "db.t3.small")]
+    DbT3small,
+    #[serde(rename = "db.t3.medium")]
+    DbT3medium,
+
+    // General purpose M4 instances for compat
     #[serde(rename = "db.m4.large")]
     DbM4Large,
-
     #[serde(rename = "db.m4.xlarge")]
     DbM4Xlarge,
-
+    #[serde(rename = "db.m4.2xlarge")]
+    DbM42xlarge,
     #[serde(rename = "db.m4.4xlarge")]
     DbM44xlarge,
 
+    // General purpose M5 instances
     #[serde(rename = "db.m5.large")]
     DbM5Large,
-
     #[serde(rename = "db.m5.xlarge")]
     DbM5Xlarge,
-
     #[serde(rename = "db.m5.2xlarge")]
     DbM52xlarge,
-
     #[serde(rename = "db.m5.4xlarge")]
     DbM54xlarge,
 }


### PR DESCRIPTION
basic info. few configurables. reducible to json output via cli.

## Usage
Add to a manifest (say services/raftcat/shipcap.yml) by adding:

```diff
+redis:
+  nodes: 2
+  nodeType: cache.m4.large
```

## Reducing

```yaml
$ shipcat get caches
---
- name: raftcat
  team: platform
  nodes: 2
  nodeType: cache.m4.large
```

then pass this list to whatever's provisioning this.

## Extra
Also removes a hidden implicit for `instanceClass` (rds module) because the same pattern in here made it obvious that it should be explicit.